### PR TITLE
More sensible default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows:
 
-      mysql_port: 3306                 # The port for mysql server to listen
-      mysql_bind_address: "0.0.0.0"    # The bind address for mysql server
-      mysql_root_db_pass: foobar       # The root DB password
+      # The port for mysql server to listen
+      mysql_port: 3306
+
+      # The bind address for mysql server, defaults to "127.0.0.1"
+      # Set it to your public "0.0.0.0" to allow external connections
+      # (i.e. for replication)
+      mysql_bind_address: "127.0.0.1"
+
+      # The root DB password
+      # by default the value is null and your root DB password is left untouched
+      mysql_root_db_pass: foobar
 
       # A list that has all the databases to be
       # created and their replication status:
@@ -59,16 +67,19 @@ database or users.
 
       - hosts: all
         roles:
-        - {role: mysql, root_db_pass: foobar, mysql_db: none, mysql_users: none }
+        - role: mysql
+          mysql_root_db_pass: foobar
 
 2) Install MySQL Server and create 2 databases and 2 users.
 
       - hosts: all
         roles:
-         - {role: mysql, mysql_db: [{name: benz},
-                                    {name: benz2}],
-            mysql_users: [{name: ben3, pass: foobar, priv: "*.*:ALL"},
-                          {name: ben2, pass: foo}] }
+          - role: mysql
+            mysql_root_db_pass: foobar
+            mysql_db: [{name: benz}, {name: benz2}]
+            mysql_users:
+              - {name: ben3, pass: foobar, priv: "*.*:ALL"}
+              - {name: ben2, pass: foo}
 
 Note: If users are specified and password/privileges are not specified, then
 default values are set.
@@ -78,27 +89,37 @@ database as replication master with one database configured for replication.
 
       - hosts: all
         roles:
-         - {role: mysql, mysql_db: [{name: benz, replicate: yes },
-                                    { name: benz2, replicate: no}], 
-                         mysql_users: [{name: ben3, pass: foobar, priv: "*.*:ALL"},
-                                       {name: ben2, pass: foo}],
-                         mysql_repl_user: [{name: repl, pass: foobar}] }
+         - role: mysql
+           mysql_root_db_pass: foobar
+           mysql_db:
+             - {name: benz, replicate: yes }
+             - {name: benz2, replicate: no}
+           mysql_users:
+             - {name: ben3, pass: foobar, priv: "*.*:ALL"}
+             - {name: ben2, pass: foo}
+           mysql_repl_user: [{name: repl, pass: foobar}]
 
 4) A fully installed/configured MySQL Server with master and slave
 replication.
 
       - hosts: master
         roles:
-         - {role: mysql, mysql_db: [{name: benz}, {name: benz2}],
-                         mysql_users: [{name: ben3, pass: foobar, priv: "*.*:ALL"},
-                                       {name: ben2, pass: foo}],
-                         mysql_db_id: 8 }
+         - role: mysql
+           mysql_db: [{name: benz}, {name: benz2}]
+           mysql_users:
+             - {name: ben3, pass: foobar, priv: "*.*:ALL"},
+             - {name: ben2, pass: foo}
+           mysql_db_id: 8
 
       - hosts: slave
         roles:
-         - {role: mysql, mysql_db: none, mysql_users: none,
-                  mysql_repl_role: slave, mysql_repl_master: vm2,
-                  mysql_db_id: 9, mysql_repl_user: [{name: repl, pass: foobar}] }
+         - role: mysql
+           mysql_db: none
+           mysql_users: none
+           mysql_repl_role: slave
+           mysql_repl_master: vm2
+           mysql_db_id: 9
+           mysql_repl_user: [{name: repl, pass: foobar}] }
 
 Note: When configuring the full replication please make sure the master is
 configured via this role and the master is available in inventory and facts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,23 +1,14 @@
 ---
 
 mysql_port: 3306
-mysql_bind_address: "0.0.0.0"
-mysql_root_db_pass: foobar
+mysql_bind_address: "127.0.0.1"
+mysql_root_db_pass: null
 
-mysql_db: 
-     - name: foo
-       replicate: yes
-     - name: bar
-       replicate: no
+mysql_db: []
 
-mysql_users:
-     - name: benz
-       pass: foobar
-       priv: "*.*:ALL"
+mysql_users: []
 
-mysql_repl_user:
-  - name: repl
-    pass: foobar
+mysql_repl_user: []
 
 mysql_repl_role: master
 mysql_db_id: 7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
    - 127.0.0.1
    - ::1
    - localhost
-  when: ansible_hostname != 'localhost' 
+  when: mysql_root_db_pass and ansible_hostname != 'localhost'
 
 - name: update mysql root password for all root accounts
   mysql_user: name=root host={{ item }} password={{ mysql_root_db_pass }}
@@ -36,10 +36,11 @@
    - 127.0.0.1
    - ::1
    - localhost
-  when: ansible_hostname == 'localhost' 
+  when: mysql_root_db_pass and ansible_hostname == 'localhost'
 
 - name: copy .my.cnf file with root password credentials
   template: src=.my.cnf.j2 dest=~/.my.cnf mode=0600
+  when: mysql_root_db_pass
 
 - name: ensure anonymous users are not in the database
   mysql_user: name='' host={{ item }} state=absent


### PR DESCRIPTION
I have implemented changes proposed in #7, is this okay? The one particular thing I am not sure about is handling of the root db password – currently the tasks related to password are skipped when the password is empty, but I was also considering to set the `mysql_root_db_pass` variable as mandatory (and then it would be better omitted from defaults completely).

However this change can distrupt existing usages of this role, so I recommend to tag your current version before merging, so Galaxy users can easily revert to the old version.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bennojoy/mysql/8)

<!-- Reviewable:end -->
