### PR TITLE
Added in task to create /etc/mysql/conf.d and include it in RedHat my.cnf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,11 @@
   notify: 
    - restart mysql
 
+- name: Create the directory /etc/mysql/conf.d
+  file: path=/etc/mysql/conf.d state=directory
+  notify:
+   - restart mysql
+
 - name: Start the mysql services Redhat
   service: name={{ mysql_service }} state=started enabled=yes
 

--- a/templates/my.cnf.RedHat.j2
+++ b/templates/my.cnf.RedHat.j2
@@ -30,4 +30,4 @@ binlog_ignore_db        = {{ i.name }}
 log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
 
-
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
This will allow other roles/tasks to drop extra configuration needed for mysql
into /etc/mysql/conf.d to further tune it
