### PR TITLE
Check if variable mysql_db is iterable

### DIFF
--- a/templates/my.cnf.Debian.j2
+++ b/templates/my.cnf.Debian.j2
@@ -38,19 +38,19 @@ log_bin                 = mysql-bin
 expire_logs_days        = 10
 max_binlog_size         = 100M
 
-{% if mysql_db is iterable %}
+{% if mysql_db is iterable and mysql_db is not string %}
 {% for i in mysql_db %}
 {% if i.replicate|default(1) %}
 binlog_do_db            = {{ i.name }}
 {% endif %}
 {% endfor %}
-{% endif %}
 
 {% for i in mysql_db %}
 {% if not i.replicate|default(1) %}
 binlog_ignore_db        = {{ i.name }}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 
 !includedir /etc/mysql/conf.d/


### PR DESCRIPTION
Execution a playbook is failed with following errors when I install MySQL without no databases.

```
TASK: [bennojoy.mysql | Copy the my.cnf file] *********************************
fatal: [127.0.0.1] => {'msg': "One or more undefined variables: 'str object' has no attribute 'name'", 'failed': True}
fatal: [127.0.0.1] => {'msg': "One or more undefined variables: 'str object' has no attribute 'name'", 'failed': True}
```

I set following variables in host_vars

``` yaml
#host_vars/127.0.0.1
mysql_port: 3306                 # The port for mysql server to listen
mysql_bind_address: "0.0.0.0"    # The bind address for mysql server
mysql_root_db_pass: foo          # The root DB password

mysql_db: none
mysql_users: none
mysql_repl_role: none
```

In `templates/my.cnf.Debian.j2`, for loop executed because `none` (str) is iterable.
I add condition to skip for loop when `mysql_db` is str or not iterable.
