### PR TITLE
fix a quoting issue that makes v2 fail

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
   when: mysql_repl_role == 'slave'
 
 - name: Ensure the hostname entry for master is available for the client.
-  lineinfile: dest=/etc/hosts regexp="{{ mysql_repl_master }}" line="{{ hostvars[mysql_repl_master].ansible_default_ipv4.address + "   " + mysql_repl_master }}" state=present
+  lineinfile: dest=/etc/hosts regexp="{{ mysql_repl_master }}" line="{{ hostvars[mysql_repl_master].ansible_default_ipv4.address + '   ' + mysql_repl_master }}" state=present
   when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
 
 - name: Get the current master servers replication status


### PR DESCRIPTION
This fixes this error using v2:
```
[mstr] [2.0.0 (devel e32d887609)] serge@goldorak:~/ansible-data$ ansible-playbook seafile.yml -C
ERROR! this task 'lineinfile' has extra params, which is only allowed in the following modules: command, shell, script, include, include_vars, add_host, group_by, set_fact, raw, meta

The error appears to have been in 'ansible-data/roles/bennojoy.mysql/tasks/main.yml': line 76, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Ensure the hostname entry for master is available for the client.
  ^ here
```